### PR TITLE
feat: do not alert when marking a message as handled

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -131,7 +131,7 @@ grp.callbackQuery([
   "handled",
   "mark-as-handled", // for the existing messages
 ]).branch(admins, async (ctx) => {
-  await ctx.alert("Marked as handled.");
+  await ctx.answerCallbackQuery("Marked as handled.");
   await ctx.deleteMessage();
 }, (ctx) => ctx.alert("Not allowed."));
 


### PR DESCRIPTION
It is a bit annoying that I have to confirm the alert modal every time I hit the button. It is enough to display the message at the top of the screen, which saves me one tap in the UI.